### PR TITLE
Add simple test config for Mocha and Chai

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ jspm_packages
 
 # File for packaged app
 build/bundle.js
+
+# Mocha-webpack output directory
+.tmp

--- a/config/webpack.test.config.js
+++ b/config/webpack.test.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+  target: 'node',
+  module: {
+    loaders: [
+      {
+        test: /\.js$/,
+        loader: 'babel',
+        query: {
+          presets: ['es2015']
+        },
+        exclude: /node_modules/
+      }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A custom browser with Vi-like keybindings, built on top of Electron.",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha-webpack --webpack-config config/webpack.test.config.js spec/specs.js",
     "start": "HEXAMER_ENV=dev ./node_modules/.bin/electron .",
     "build": "./node_modules/.bin/webpack --config ./config/webpack.config.js",
     "watch": "./node_modules/.bin/webpack-dev-server --hot --inline --config ./config/webpack.config.js"
@@ -27,9 +27,13 @@
   "devDependencies": {
     "babel-core": "^6.10.4",
     "babel-loader": "^6.2.4",
+    "babel-preset-es2015": "^6.14.0",
     "babel-preset-react": "^6.11.1",
+    "chai": "^3.5.0",
     "css-loader": "^0.23.1",
     "electron-prebuilt": "^1.2.5",
+    "mocha": "^3.0.2",
+    "mocha-webpack": "^0.6.0",
     "node-sass": "^3.8.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",

--- a/spec/specs.js
+++ b/spec/specs.js
@@ -1,0 +1,7 @@
+import { chai, expect } from 'chai';
+
+describe('a fake test', () => {
+  it('always returns true', () => {
+    expect(true).to.equal(true);
+  });
+});


### PR DESCRIPTION
For the moment, this testing setup doesn't really take Electron into account. Will probably need to update with a more complex config in the future to test the client-side features.